### PR TITLE
Union node validations

### DIFF
--- a/src/nlp-visual-editor/nlp-visual-editor.jsx
+++ b/src/nlp-visual-editor/nlp-visual-editor.jsx
@@ -146,7 +146,7 @@ class VisualEditor extends React.Component {
     let response = {};
     const isValid = upstreamNodeIds.every((id) => {
       const node = nodes.find((n) => n.nodeId === id);
-      response = this.nodeValidator.validate(pipelineId, node);
+      response = this.nodeValidator.validate(pipelineId, node, nodes);
       const { isValid } = response;
       return isValid;
     });

--- a/src/utils/NodeValidator.js
+++ b/src/utils/NodeValidator.js
@@ -27,7 +27,7 @@ import {
 
 export default function NodeValidator(canvasController) {
   this.canvasController = canvasController;
-  this.validate = function (pipelineId, nodeProps) {
+  this.validate = function (pipelineId, nodeProps, nodes) {
     const { type } = nodeProps;
     let node;
     switch (type) {
@@ -44,7 +44,7 @@ export default function NodeValidator(canvasController) {
         node = new SequenceNode(this.canvasController, pipelineId, nodeProps);
         break;
       case 'union':
-        node = new UnionNode(this.canvasController, pipelineId, nodeProps);
+        node = new UnionNode(this.canvasController, pipelineId, nodeProps, nodes);
 		break;
 	  case 'filter':
 		node = new FilterNode(this.canvasController, pipelineId, nodeProps);


### PR DESCRIPTION
Union Node validations so that upstream nodes have attributes aligned.
Attributes aligned =>
  - Renamed Attributes are the same
  - No upstream visible

<img width="1298" alt="Screen Shot 2022-06-20 at 10 57 49 AM" src="https://user-images.githubusercontent.com/746516/174656908-ae069a73-f0e3-4027-a1b8-ec8f6a2a613d.png">

Upstream nodes to Union have attribute controls (Sequence shown below)
Top is forced active but can be renamed
Others are upstream inputs, and need to be hidden (unchecked)
<img width="212" alt="Screen Shot 2022-06-20 at 11 02 16 AM" src="https://user-images.githubusercontent.com/746516/174657097-733ddaf1-fec5-4d96-be6c-907d9d09679e.png">

