### PR TITLE
Add dialog on close to confirm unsaved changes

### DIFF
--- a/src/redux/slice.js
+++ b/src/redux/slice.js
@@ -27,7 +27,8 @@ const initialState = {
   moduleName: 'elyraNLPCanvas',
   showRightPanel: false,
   showDocumentViewer: false,
-  currentAnnotation: undefined
+  currentAnnotation: undefined,
+  dirty: false,
 };
 
 const nodesSlice = createSlice({
@@ -59,6 +60,7 @@ const nodesSlice = createSlice({
         return !ids.includes(n.nodeId);
       });
       state.nodes = newNodes;
+      state.dirty = true;
     },
     saveNlpNode: (state, action) => {
       //stores or replaces node.
@@ -69,11 +71,13 @@ const nodesSlice = createSlice({
       const updatedNode = { ...existingNode, ...node };
       const nodeList = state.nodes.filter((n) => n.nodeId !== nodeId);
       state.nodes = nodeList.concat(updatedNode);
+      state.dirty = true;
     },
     setNlpNodes: (state, action) => {
       // called when saved pipeline json is opened
       const { nodes = [] } = action.payload;
       state.nodes = nodes;
+      state.dirty = true;
     },
     setInputDocument: (state, action) => {
       const { document } = action.payload;
@@ -86,12 +90,15 @@ const nodesSlice = createSlice({
       } else {
         const { annotations, names } = payload;
         state.tabularResults = { annotations, names };
-		state.currentAnnotation = names[0];
+        state.currentAnnotation = names[0];
       }
     },
-	setDocumentViewToAnnotation: (state, action) => {
-		state.currentAnnotation = action.payload;
-	}
+    setDocumentViewToAnnotation: (state, action) => {
+      state.currentAnnotation = action.payload;
+    },
+    setDirty: (state, action) => {
+      state.dirty = action.payload;
+    },
   },
 });
 
@@ -106,5 +113,6 @@ export const {
   setShowRightPanel,
   setShowDocumentViewer,
   setDocumentViewToAnnotation,
+  setDirty,
 } = nodesSlice.actions;
 export default nodesSlice.reducer;


### PR DESCRIPTION
Fixes #63 - if any edits are made and haven't been saved a dialog will appear when the user tries to close the tab to confirm that they'll lose unsaved changes. To add a button that actually triggers a save from that dialog we'd need to add another package and a bit more work but this covers at least most of the concerns of the issue. 
<img width="1067" alt="image" src="https://user-images.githubusercontent.com/6673460/174916577-55181c7b-1e5c-4182-aae1-9e6547f03a7a.png">
