### PR TITLE
Add save as dialog

### DIFF
--- a/src/nlp-visual-editor/nlp-visual-editor.jsx
+++ b/src/nlp-visual-editor/nlp-visual-editor.jsx
@@ -253,8 +253,19 @@ class VisualEditor extends React.Component {
       flow,
       nodes: newNodes,
     };
-    fileDownload(JSON.stringify(data), 'NLP_Canvas_Flow.json');
-    this.props.setDirty(false);
+    const opts = {
+      suggestedName: 'NLP_Canvas_Flow.json',
+      types: [
+        {
+          description: 'JSON file',
+          accept: { 'application/json': ['.json'] },
+        },
+      ],
+    };
+    window.showSaveFilePicker(opts).then((args) => {
+      fileDownload(JSON.stringify(data), args.name);
+      this.props.setDirty(false);
+    });
   };
 
   setPipelineFlow = ({ flow, nodes }) => {


### PR DESCRIPTION
Fixes #72 to add the ability to "save as". Opens this dialog with the filename "NLP_Canvas_Flow.json" auto-filled. 
![image](https://user-images.githubusercontent.com/6673460/176260700-05922605-84b6-4baf-8a5a-b91b3ef174aa.png)
