### PR TITLE
Add save as dialog for export

### DIFF
--- a/src/nlp-visual-editor/nlp-visual-editor.jsx
+++ b/src/nlp-visual-editor/nlp-visual-editor.jsx
@@ -268,6 +268,27 @@ class VisualEditor extends React.Component {
     });
   };
 
+  exportPipeline = () => {
+    const opts = {
+      suggestedName: 'NLP_Canvas_Export.zip',
+      types: [
+        {
+          description: 'Zip file',
+          accept: { 'application/octet-stream': ['.zip'] },
+        },
+      ],
+    };
+    window.showSaveFilePicker(opts).then((args) => {
+      axios
+        .get(`/api/download/${this.props.pipelineId}`, {
+          responseType: 'arraybuffer',
+        })
+        .then((res) => {
+          fileDownload(res.data, args.name);
+        });
+    });
+  };
+
   setPipelineFlow = ({ flow, nodes }) => {
     const { primary_pipeline: pipelineId } = flow;
     this.props.setShowRightPanel({ showPanel: false });
@@ -373,9 +394,7 @@ class VisualEditor extends React.Component {
               size="field"
               kind="ghost"
               disabled={this.props.tabularResults === undefined}
-              onClick={() =>
-                window.open(`/api/download/${this.props.pipelineId}`)
-              }
+              onClick={this.exportPipeline}
             >
               Export
             </Button>

--- a/src/nlp-visual-editor/views/components/table-results.jsx
+++ b/src/nlp-visual-editor/views/components/table-results.jsx
@@ -28,40 +28,39 @@ import {
 } from 'carbon-components-react';
 
 const hasAttributeResult = (tabularData, docName, onRowSelected) => {
-  return tabularData.map((row, index) => (
-    <TableRow key={`row_${index}`}>
-      <TableCell key={`doc-name_${index}`}>{docName}</TableCell>
-      {Object.keys(row).map((key) => (
-        <TableCell
-          onClick={() => onRowSelected({ indexResult: index })}
-          key={`row-text_${key}_${index}`}
-        >
-          {row[key]['text']}
-        </TableCell>
-      ))}
-    </TableRow>
-  ));
-};
+	return tabularData.map((row, index) => (
+		<TableRow
+		  key={`row_${index}`}
+		>
+		  <TableCell key={`doc-name_${index}`}>{docName}</TableCell>
+		  {
+		  	Object.keys(row).map( key => (
+			  <TableCell onClick={() => onRowSelected({indexResult: index})} key={`row-text_${key}_${index}`}>{row[key]['text']}</TableCell>
+			))
+		  }
+		</TableRow>
+	))
+}
 
 const TableResults = ({ tabularData, label, docName = '', onRowSelected }) => {
   const mockedHeaders = ['Document'];
-  Object.keys(tabularData[0]).forEach((key) => {
-    mockedHeaders.push(key);
-  });
+  Object.keys(tabularData[0]).forEach( key => {
+	mockedHeaders.push(key)
+  })
   return (
     <div className="table-results">
       <Table size="sm">
         <TableHead>
           <TableRow>
             {mockedHeaders.map((header, i) => (
-              <TableHeader id={header} key={header} style={{ width: '100%' }}>
+              <TableHeader id={header} key={header}>
                 {header} {i == 1 ? `(${tabularData.length})` : ''}
               </TableHeader>
             ))}
           </TableRow>
         </TableHead>
         <TableBody>
-          {hasAttributeResult(tabularData, docName, onRowSelected)}
+          { hasAttributeResult(tabularData, docName, onRowSelected) }
         </TableBody>
       </Table>
     </div>

--- a/src/nlp-visual-editor/views/components/table-results.jsx
+++ b/src/nlp-visual-editor/views/components/table-results.jsx
@@ -28,39 +28,40 @@ import {
 } from 'carbon-components-react';
 
 const hasAttributeResult = (tabularData, docName, onRowSelected) => {
-	return tabularData.map((row, index) => (
-		<TableRow
-		  key={`row_${index}`}
-		>
-		  <TableCell key={`doc-name_${index}`}>{docName}</TableCell>
-		  {
-		  	Object.keys(row).map( key => (
-			  <TableCell onClick={() => onRowSelected({indexResult: index})} key={`row-text_${key}_${index}`}>{row[key]['text']}</TableCell>
-			))
-		  }
-		</TableRow>
-	))
-}
+  return tabularData.map((row, index) => (
+    <TableRow key={`row_${index}`}>
+      <TableCell key={`doc-name_${index}`}>{docName}</TableCell>
+      {Object.keys(row).map((key) => (
+        <TableCell
+          onClick={() => onRowSelected({ indexResult: index })}
+          key={`row-text_${key}_${index}`}
+        >
+          {row[key]['text']}
+        </TableCell>
+      ))}
+    </TableRow>
+  ));
+};
 
 const TableResults = ({ tabularData, label, docName = '', onRowSelected }) => {
   const mockedHeaders = ['Document'];
-  Object.keys(tabularData[0]).forEach( key => {
-	mockedHeaders.push(key)
-  })
+  Object.keys(tabularData[0]).forEach((key) => {
+    mockedHeaders.push(key);
+  });
   return (
     <div className="table-results">
       <Table size="sm">
         <TableHead>
           <TableRow>
             {mockedHeaders.map((header, i) => (
-              <TableHeader id={header} key={header}>
+              <TableHeader id={header} key={header} style={{ width: '100%' }}>
                 {header} {i == 1 ? `(${tabularData.length})` : ''}
               </TableHeader>
             ))}
           </TableRow>
         </TableHead>
         <TableBody>
-          { hasAttributeResult(tabularData, docName, onRowSelected) }
+          {hasAttributeResult(tabularData, docName, onRowSelected)}
         </TableBody>
       </Table>
     </div>


### PR DESCRIPTION
Fixes #73. Adds a dialog to prompt the user for the path for the exported file to be downloaded at. The default filename is "NLP_Canvas_Export.zip"
<img width="1246" alt="image" src="https://user-images.githubusercontent.com/6673460/177394406-492d171b-f634-49db-8b34-65ae7446a0e4.png">
