### PR TITLE
Add tooltip to tabs in results table

### DIFF
--- a/src/nlp-visual-editor/views/components/table-results.jsx
+++ b/src/nlp-visual-editor/views/components/table-results.jsx
@@ -28,39 +28,44 @@ import {
 } from 'carbon-components-react';
 
 const hasAttributeResult = (tabularData, docName, onRowSelected) => {
-	return tabularData.map((row, index) => (
-		<TableRow
-		  key={`row_${index}`}
-		>
-		  <TableCell key={`doc-name_${index}`}>{docName}</TableCell>
-		  {
-		  	Object.keys(row).map( key => (
-			  <TableCell onClick={() => onRowSelected({indexResult: index})} key={`row-text_${key}_${index}`}>{row[key]['text']}</TableCell>
-			))
-		  }
-		</TableRow>
-	))
-}
+  return tabularData.map((row, index) => (
+    <TableRow key={`row_${index}`}>
+      <TableCell key={`doc-name_${index}`}>{docName}</TableCell>
+      {Object.keys(row).map((key) => (
+        <TableCell
+          onClick={() => onRowSelected({ indexResult: index })}
+          key={`row-text_${key}_${index}`}
+        >
+          {row[key]['text']}
+        </TableCell>
+      ))}
+    </TableRow>
+  ));
+};
 
 const TableResults = ({ tabularData, label, docName = '', onRowSelected }) => {
   const mockedHeaders = ['Document'];
-  Object.keys(tabularData[0]).forEach( key => {
-	mockedHeaders.push(key)
-  })
+  Object.keys(tabularData[0]).forEach((key) => {
+    mockedHeaders.push(key);
+  });
   return (
     <div className="table-results">
       <Table size="sm">
         <TableHead>
           <TableRow>
             {mockedHeaders.map((header, i) => (
-              <TableHeader id={header} key={header}>
+              <TableHeader
+                id={header}
+                key={header}
+                title={`${header} ${i == 1 ? `(${tabularData.length})` : ''}`}
+              >
                 {header} {i == 1 ? `(${tabularData.length})` : ''}
               </TableHeader>
             ))}
           </TableRow>
         </TableHead>
         <TableBody>
-          { hasAttributeResult(tabularData, docName, onRowSelected) }
+          {hasAttributeResult(tabularData, docName, onRowSelected)}
         </TableBody>
       </Table>
     </div>

--- a/src/nlp-visual-editor/views/tabular-view.jsx
+++ b/src/nlp-visual-editor/views/tabular-view.jsx
@@ -70,7 +70,13 @@ class TabularView extends React.Component {
       const table = this.getTable(name);
       const tabId = `${name.toLowerCase()}_id`;
       tabs.push(
-        <Tab id={tabId} key={tabId} label={name} onClick={() => this.props.setDocumentAnnotation(name)}>
+        <Tab
+          id={tabId}
+          key={tabId}
+          label={name}
+          title={name}
+          onClick={() => this.props.setDocumentAnnotation(name)}
+        >
           {table}
         </Tab>,
       );
@@ -90,6 +96,7 @@ const mapStateToProps = (state) => ({
 });
 
 const mapDispatchToProps = (dispatch) => ({
-	setDocumentAnnotation: (annotation) => dispatch( setDocumentViewToAnnotation(annotation))
-})
+  setDocumentAnnotation: (annotation) =>
+    dispatch(setDocumentViewToAnnotation(annotation)),
+});
 export default connect(mapStateToProps, mapDispatchToProps)(TabularView);


### PR DESCRIPTION
Adds tooltip to be able to differentiate tabs with long labels. For #67 (but doesn't add adjustable widths, so we could keep that open if that's still a request). 
![image](https://user-images.githubusercontent.com/6673460/192858380-918504e1-9945-41e0-8b46-50361b82b24d.png)
