### PR TITLE
Add initial support for mapped terms in dictionary nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "carbon-icons": "^7.0.7",
     "classnames": "^2.3.1",
     "cors": "^2.8.5",
+    "csv-parse": "^5.3.0",
     "express": "^4.17.2",
     "express-fileupload": "^1.3.1",
     "express-rate-limit": "^6.5.2",

--- a/server.js
+++ b/server.js
@@ -273,7 +273,7 @@ const formatResults = ({ annotations, instrumentationInfo }) => {
         const { location, text } = elem[key];
         attributes[key] = {
           start: location?.begin,
-          end: location?.begin,
+          end: location?.end,
           text: text ?? elem[key],
         };
       });

--- a/server.js
+++ b/server.js
@@ -161,7 +161,9 @@ app.get(
     }
 
     const { workingId } = req.params;
-    const destinationPath = `${systemTdataFolder}/user-data-in/${sanitize(workingId)}.export-aql`;
+    const destinationPath = `${systemTdataFolder}/user-data-in/${sanitize(
+      workingId,
+    )}.export-aql`;
     fs.writeFileSync(destinationPath, '');
     const resultFileName = `${sanitize(workingId)}.zip`;
     const file = `${systemTdataFolder}/run-aql-result/${resultFileName}`;
@@ -219,7 +221,7 @@ app.post(
     console.time('writing xml files');
     fs.readdirSync(workingFolder)
       .filter((f) => f.endsWith('.xml'))
-      .forEach((f) => fs.unlinkSync( `${workingFolder}/${f}`));
+      .forEach((f) => fs.unlinkSync(`${workingFolder}/${f}`));
 
     //write files to temp folder
     payload.forEach((node) => {
@@ -269,8 +271,11 @@ const formatResults = ({ annotations, instrumentationInfo }) => {
       const attributes = {};
       Object.keys(elem).forEach((key) => {
         const { location, text } = elem[key];
-        const { begin: start, end } = location;
-        attributes[key] = { start, end, text };
+        attributes[key] = {
+          start: location?.begin,
+          end: location?.begin,
+          text: text ?? elem[key],
+        };
       });
       items.push({ ...attributes });
     });

--- a/src/nlp-visual-editor/components/rhs-panel.scss
+++ b/src/nlp-visual-editor/components/rhs-panel.scss
@@ -17,8 +17,9 @@ limitations under the License.
 .rhs-panel-container {
   min-width: 500px;
   max-width: 500px;
-  padding: 0 1rem;
+  padding: 0 1rem 100px 1rem;
   height: 100%;
+  overflow: scroll;
 
   .rhs-panel-header {
     padding: 1rem 0 1.5rem 0;

--- a/src/nlp-visual-editor/components/rhs-panel.scss
+++ b/src/nlp-visual-editor/components/rhs-panel.scss
@@ -45,7 +45,7 @@ limitations under the License.
   }
 
   .rhs-buttons {
-    position: absolute;
+    position: fixed;
     bottom: 0;
     right: 8rem;
     max-width: 8rem;

--- a/src/nlp-visual-editor/nlp-visual-editor.scss
+++ b/src/nlp-visual-editor/nlp-visual-editor.scss
@@ -27,6 +27,7 @@ limitations under the License.
 
   .right-flyout-panel {
     border-left: 1px solid #e0e0e0;
+    overflow: scroll;
   }
 
   .warning-modal {

--- a/src/nlp-visual-editor/nlp-visual-editor.scss
+++ b/src/nlp-visual-editor/nlp-visual-editor.scss
@@ -27,7 +27,6 @@ limitations under the License.
 
   .right-flyout-panel {
     border-left: 1px solid #e0e0e0;
-    overflow: scroll;
   }
 
   .warning-modal {

--- a/src/nlp-visual-editor/nodes/components/dictionary-panel.jsx
+++ b/src/nlp-visual-editor/nodes/components/dictionary-panel.jsx
@@ -233,17 +233,17 @@ class DictionaryPanel extends React.Component {
             mapTerms
               ? [
                   {
-                    header: 'Value',
+                    header: 'Term',
                     key: 'value',
                   },
                   {
-                    header: 'Mapped',
+                    header: 'Mapped Term',
                     key: 'mapped',
                   },
                 ]
               : [
                   {
-                    header: 'Value',
+                    header: 'Term',
                     key: 'value',
                   },
                 ]
@@ -310,10 +310,10 @@ class DictionaryPanel extends React.Component {
                       <TableRow key="headerRow">
                         <TableSelectAll {...props.getSelectionProps()} />
                         <TableHeader id="valueHeader" key="valueHeader">
-                          Value
+                          Term
                         </TableHeader>
                         <TableHeader id="mappedHeader" key="mappedHeader">
-                          Mapped
+                          Mapped Term
                         </TableHeader>
                       </TableRow>
                     </TableHead>

--- a/src/nlp-visual-editor/nodes/components/dictionary-panel.jsx
+++ b/src/nlp-visual-editor/nodes/components/dictionary-panel.jsx
@@ -227,6 +227,8 @@ class DictionaryPanel extends React.Component {
               };
             }
           })}
+          invalid={errorMessage !== undefined}
+          invalidText={errorMessage}
           headers={
             mapTerms
               ? [
@@ -248,7 +250,9 @@ class DictionaryPanel extends React.Component {
           }
           render={(props) => {
             return (
-              <TableContainer>
+              <TableContainer
+                style={{ marginBottom: '10px', marginTop: '10px' }}
+              >
                 <TableToolbar>
                   <TableBatchActions
                     {...props.getBatchActionProps({
@@ -262,15 +266,20 @@ class DictionaryPanel extends React.Component {
                       renderIcon={Delete16}
                     />
                   </TableBatchActions>
-                  <TableToolbarContent>
+                  <TableToolbarContent style={{ height: 'fit-content' }}>
                     <TextInput
                       value={this.state.inputText}
+                      invalid={errorMessage !== undefined}
+                      invalidText={errorMessage}
                       placeholder="Enter a phrase to match..."
                       onChange={(event) => {
                         this.setState({ inputText: event.target.value ?? '' });
                       }}
                       onKeyDown={(event) => {
-                        if (event.keyCode === 13) {
+                        if (
+                          event.keyCode === 13 &&
+                          this.state.inputText !== ''
+                        ) {
                           this.setState({
                             items: [...items, this.state.inputText],
                             inputText: '',
@@ -281,10 +290,12 @@ class DictionaryPanel extends React.Component {
                     <Button
                       tabIndex={0}
                       onClick={() => {
-                        this.setState({
-                          items: [...items, this.state.inputText],
-                          inputText: '',
-                        });
+                        if (this.state.inputText !== '') {
+                          this.setState({
+                            items: [...items, this.state.inputText],
+                            inputText: '',
+                          });
+                        }
                       }}
                       size="small"
                       kind="primary"

--- a/src/nlp-visual-editor/nodes/components/dictionary-panel.jsx
+++ b/src/nlp-visual-editor/nodes/components/dictionary-panel.jsx
@@ -123,12 +123,14 @@ class DictionaryPanel extends React.Component {
   };
 
   onDeleteItems = (props) => {
-    const { items } = this.state;
+    const { items, mappedItems } = this.state;
     const itemsSet = new Set(items);
+    const newMapped = { ...mappedItems };
     props.selectedRows.forEach((row) => {
       itemsSet.delete(row.id);
+      delete newMapped[row.id];
     });
-    this.setState({ items: Array.from(itemsSet) });
+    this.setState({ items: Array.from(itemsSet), mappedItems: newMapped });
   };
 
   onChangeLemmaCaseMatch = (value) => {

--- a/src/nlp-visual-editor/nodes/components/dictionary-panel.jsx
+++ b/src/nlp-visual-editor/nodes/components/dictionary-panel.jsx
@@ -81,6 +81,9 @@ class DictionaryPanel extends React.Component {
             const newItems = [];
             const newMapped = {};
             for (const rec of records) {
+              if (rec[0] === '') {
+                continue;
+              }
               if (!items.includes(rec[0])) {
                 newItems.push(rec[0]);
               }
@@ -95,7 +98,7 @@ class DictionaryPanel extends React.Component {
       } else {
         let newItems = event.target.result?.split('\n');
         newItems = newItems.filter((i) => {
-          return items.indexOf(i) < 0;
+          return items.indexOf(i) < 0 && i !== '';
         });
         this.setState({ items: [...items, ...newItems] });
       }

--- a/src/nlp-visual-editor/nodes/components/dictionary-panel.jsx
+++ b/src/nlp-visual-editor/nodes/components/dictionary-panel.jsx
@@ -210,6 +210,8 @@ class DictionaryPanel extends React.Component {
                 mapped: (
                   <TextInput
                     value={mappedItems[item] ?? ''}
+                    placeholder="Enter a phrase to map to..."
+                    labelText=""
                     onChange={(event) => {
                       const newMapped = Object.assign({}, mappedItems);
                       newMapped[item] = event.target.value;
@@ -263,6 +265,7 @@ class DictionaryPanel extends React.Component {
                   <TableToolbarContent>
                     <TextInput
                       value={this.state.inputText}
+                      placeholder="Enter a phrase to match..."
                       onChange={(event) => {
                         this.setState({ inputText: event.target.value ?? '' });
                       }}

--- a/src/nlp-visual-editor/nodes/components/dictionary-panel.jsx
+++ b/src/nlp-visual-editor/nodes/components/dictionary-panel.jsx
@@ -55,11 +55,15 @@ class DictionaryPanel extends React.Component {
 
   constructor(props) {
     super(props);
+    const filterItems = (item) => {
+      return item !== '';
+    };
+    const filteredItems = Array.isArray(props.items ?? [])
+      ? props.items?.filter(filterItems) ?? []
+      : Object.keys(props.items).filter(filterItems);
     this.state = {
       inputText: '',
-      items: Array.isArray(props.items ?? [])
-        ? props.items ?? []
-        : Object.keys(props.items),
+      items: filteredItems,
       caseSensitivity: props.caseSensitivity,
       lemmaMatch: props.lemmaMatch,
       externalResourceChecked: props.externalResourceChecked,

--- a/src/nlp-visual-editor/nodes/components/dictionary-panel.scss
+++ b/src/nlp-visual-editor/nodes/components/dictionary-panel.scss
@@ -36,12 +36,6 @@ limitations under the License.
     }
   }
 
-  select {
-    border: 0;
-    background-color: #f4f4f4;
-    margin-bottom: 1.5rem;
-  }
-
   .bx--checkbox-wrapper {
     padding-bottom: 1rem;
   }

--- a/src/nlp-visual-editor/views/components/nlp-results-highlight.jsx
+++ b/src/nlp-visual-editor/views/components/nlp-results-highlight.jsx
@@ -24,6 +24,7 @@ const NlpResultsHighlight = ({ textToHighlight, spans }) => {
   let lastIndex = 0;
   spans.forEach((span) => {
     const { start, end, color } = span;
+    console.log(span);
     if (lastIndex < start) {
       const text = textToHighlight.substring(lastIndex, start);
       chunks.push({ text, start: lastIndex, end: start, highlight: false });

--- a/src/utils/transform/DictionaryNode.js
+++ b/src/utils/transform/DictionaryNode.js
@@ -104,7 +104,7 @@ export default class DictionaryNode {
     if (mapTerms) {
       fieldValues.push({
         '@': {
-          name: `normalized${fieldName}`,
+          name: `Mapped`,
           'mapped-entry': 'yes',
           hide: 'no',
         },

--- a/src/utils/transform/DictionaryNode.js
+++ b/src/utils/transform/DictionaryNode.js
@@ -28,20 +28,17 @@ export default class DictionaryNode {
   getEntries = () => {
     const { items, mapTerms } = this.node;
     const entries = [];
-    if (mapTerms) {
-      for (const item in items) {
+    for (const item in items) {
+      if (mapTerms) {
         entries.push({
           'dict-entry': item,
           'mapped-entry': items[item],
         });
+      } else {
+        entries.push(items[item]);
       }
-      return entries;
-    } else {
-      items.forEach((item) => {
-        entries.push(item);
-      });
-      return entries;
     }
+    return entries;
   };
 
   getOutputSpecName = () => {
@@ -94,19 +91,23 @@ export default class DictionaryNode {
     const isCaseSensitive = caseSensitivity === 'match';
     const fieldValues = [
       {
-        name: fieldName, //node name lowercase
-        group: 0,
-        hide: 'no',
-        'func-call': 'no',
-        renamed: 'no',
-        type: 'Span',
+        '@': {
+          name: fieldName, //node name lowercase
+          group: 0,
+          hide: 'no',
+          'func-call': 'no',
+          renamed: 'no',
+          type: 'Span',
+        },
       },
     ];
     if (mapTerms) {
       fieldValues.push({
-        name: `normalized${fieldName}`,
-        'mapped-entry': 'yes',
-        hide: 'no',
+        '@': {
+          name: `normalized${fieldName}`,
+          'mapped-entry': 'yes',
+          hide: 'no',
+        },
       });
     }
     const jsonStructure = {
@@ -135,7 +136,7 @@ export default class DictionaryNode {
           },
         },
         'output-spec': {
-          field: { fieldValues },
+          field: fieldValues,
         },
         'rule-spec': {
           'dictionary-match': {

--- a/src/utils/transform/DictionaryNode.js
+++ b/src/utils/transform/DictionaryNode.js
@@ -104,7 +104,7 @@ export default class DictionaryNode {
     if (mapTerms) {
       fieldValues.push({
         '@': {
-          name: `Mapped`,
+          name: `Mapped Term`,
           'mapped-entry': 'yes',
           hide: 'no',
         },


### PR DESCRIPTION
**Questions**: 
* If `mapTerms` is true and an item has a term but no value that it maps to, this does not save that item. Should that be added as validation? What is the preferred behavior? 
* Are the placeholders, names of columns, etc. correct? 

Fixes #101. Adds a switch to the dictionary node panel to turn on "Map Terms", which changes the list of terms to a table with two columns:
![image](https://user-images.githubusercontent.com/6673460/193644421-bb230c74-3370-46ff-a3cb-e2a43bd6d44d.png)

Also updates the list of terms when "Map Terms" is off to be more consistent with the rest of the UI:
![image](https://user-images.githubusercontent.com/6673460/193644310-477d359c-2bca-4dd4-a6a1-48ef1eae9e7e.png)
![image](https://user-images.githubusercontent.com/6673460/193644339-2e7169d4-d9ec-443e-8016-94cbb9ad738b.png)


**JSON Changes**:
* Adds a new field to the JSON called `mapTerms`
* If `mapTerms` is false (or undefined for old pipelines), the format of the JSON stays the same
* If `mapTerms` is true, the `items` field is a dictionary that maps the terms to their "mapped" values. 
