### PR TITLE
Fix dictionary table bug

### DIFF
--- a/src/nlp-visual-editor/nodes/components/dictionary-panel.jsx
+++ b/src/nlp-visual-editor/nodes/components/dictionary-panel.jsx
@@ -193,7 +193,7 @@ class DictionaryPanel extends React.Component {
   getDisplayedItems() {
     const { items, page, pageSize } = this.state;
     const start = (page - 1) * pageSize;
-    const end = page * pageSize - 1;
+    const end = page * pageSize;
     return items.slice(start, end);
   }
 


### PR DESCRIPTION
Closes #110 

Bug introduced in #107 - the table was only showing 9 out of 10 entries that should be displayed: 
![image](https://user-images.githubusercontent.com/6673460/197854070-d4b07fd9-034f-4770-a75b-a2b43d2ffc17.png)

Fixes it to show all entries:
![image](https://user-images.githubusercontent.com/6673460/197854161-a48b7414-57e9-49dd-a0f1-14a1b289b739.png)
