### PR TITLE
Fix settings bug

### DIFF
--- a/src/nlp-visual-editor/nlp-visual-editor.jsx
+++ b/src/nlp-visual-editor/nlp-visual-editor.jsx
@@ -19,14 +19,18 @@ import { IntlProvider } from 'react-intl';
 import { connect, Provider } from 'react-redux';
 import axios from 'axios';
 import shortUUID from 'short-uuid';
-import { CommonCanvas, CanvasController, CommonProperties } from '@elyra/canvas';
+import {
+  CommonCanvas,
+  CanvasController,
+  CommonProperties,
+} from '@elyra/canvas';
 import { Button, Loading, Modal, Select } from 'carbon-components-react';
 import {
   Play32,
   WarningAlt24,
   DocumentDownload32,
   Upload16,
-  SettingsAdjust32
+  SettingsAdjust32,
 } from '@carbon/icons-react';
 import nlpPalette from '../config/nlpPalette.json';
 import RHSPanel from './components/rhs-panel';
@@ -53,7 +57,7 @@ import {
   setShowRightPanel,
   setShowDocumentViewer,
   setDirty,
-  setModuleName
+  setModuleName,
 } from '../redux/slice';
 
 const TIMER_TICK = 250; // 1/4 second
@@ -100,13 +104,15 @@ class VisualEditor extends React.Component {
       errorMessage: undefined,
       languageSelectModal: false,
       showSettings: false,
-      editorSettings: localStorage.getItem('nlpEditorSettings') ? JSON.parse(localStorage.getItem('nlpEditorSettings')) : {
-        moduleName: 'elyraNLPCanvas',
-        language: 'en'
-      }
+      editorSettings: localStorage.getItem('nlpEditorSettings')
+        ? JSON.parse(localStorage.getItem('nlpEditorSettings'))
+        : {
+            moduleName: 'elyraNLPCanvas',
+            language: 'en',
+          },
     };
 
-    this.props.setModuleName( this.state.editorSettings.moduleName);
+    this.props.setModuleName(this.state.editorSettings.moduleName);
 
     this.canvasController = new CanvasController();
     this.canvasController.openPalette();
@@ -257,7 +263,7 @@ class VisualEditor extends React.Component {
       body: JSON.stringify({
         workingId,
         payload,
-        language: this.getCurrentLanguage(),
+        language: this.getCurrentLanguage() ?? 'en',
       }),
     })
       .then((res) => res.json())
@@ -360,7 +366,7 @@ class VisualEditor extends React.Component {
 
   getCurrentLanguage = () => {
     const flow = this.canvasController.getPipelineFlow();
-    return flow.pipelines?.[0]?.app_data?.language ?? 'en';
+    return flow.pipelines?.[0]?.app_data?.language;
   };
 
   setCurrentLanguage = (language) => {
@@ -370,9 +376,7 @@ class VisualEditor extends React.Component {
         ...flow.pipelines[0].app_data,
         language: language,
       };
-      console.log(flow);
       this.canvasController.setPipelineFlow(flow);
-      console.log(this.canvasController.getPipelineFlow());
     }
   };
 
@@ -403,6 +407,15 @@ class VisualEditor extends React.Component {
         throw 'File does not conform to the Elyra NLP Tooling schema.';
       }
       this.setPipelineFlow(data);
+      if (data.flow.pipelines?.[0]?.app_data?.language) {
+        this.setCurrentLanguage(data.flow.pipelines[0].app_data.language);
+        this.setState({
+          editorSettings: {
+            ...this.state.editorSettings,
+            language: data.flow.pipelines[0].app_data.language,
+          },
+        });
+      }
     } catch (ex) {
       console.log(ex);
       const errorMessage = typeof ex === 'object' ? ex.toString() : ex;
@@ -414,8 +427,8 @@ class VisualEditor extends React.Component {
     this.props.setShowRightPanel({ showPanel: true });
     this.props.setShowDocumentViewer({ showViewer: false });
     this.setState({
-      showSettings: true
-    })
+      showSettings: true,
+    });
   }
 
   getToolbar = () => {
@@ -522,13 +535,8 @@ class VisualEditor extends React.Component {
           tooltip: 'Select Language',
           jsx: (
             <>
-              <Button
-                id={'btn-language'}
-                size="field"
-                kind="ghost"
-                disabled
-              >
-                Language ({languages[this.getCurrentLanguage()]})
+              <Button id={'btn-language'} size="field" kind="ghost" disabled>
+                Language ({languages[this.state.editorSettings.language]})
               </Button>
             </>
           ),
@@ -665,61 +673,66 @@ class VisualEditor extends React.Component {
       parameterDef: {
         titleDefinition: {
           title: 'NLP Settings',
-          editable: false
+          editable: false,
         },
-        current_parameters: {
-          moduleName: this.state.editorSettings.moduleName,
-          language: this.getCurrentLanguage()
-        },
-        parameters: [{
-          id: 'moduleName',
-          type: 'string',
-          default: ''
-        }, {
-          id: 'language',
-          type: 'string'
-        }],
+        current_parameters: this.state.editorSettings,
+        parameters: [
+          {
+            id: 'moduleName',
+            type: 'string',
+            default: '',
+          },
+          {
+            id: 'language',
+            type: 'string',
+          },
+        ],
         uihints: {
           id: 'Settings',
           editor_size: 'medium',
           label: {
-            default: 'General Settings'
+            default: 'General Settings',
           },
-          parameter_info: [{
-            parameter_ref: 'moduleName',
-            label: {
-              default: 'Module Name'
+          parameter_info: [
+            {
+              parameter_ref: 'moduleName',
+              label: {
+                default: 'Module Name',
+              },
+              description: {
+                default: 'Module Name',
+              },
             },
-            description: {
-              default: 'Module Name'
-            }
-          }],
-          action_info: [{
-            id: 'language',
-            label: {
-              default: 'Select Language'
+          ],
+          action_info: [
+            {
+              id: 'language',
+              label: {
+                default: `Select Language (${
+                  languages[this.state.editorSettings.language]
+                })`,
+              },
+              control: 'button',
             },
-            control: 'button'
-          }],
-          group_info: [{
-            id: 'settings',
-            label: {
-              default: 'Settings'
+          ],
+          group_info: [
+            {
+              id: 'settings',
+              label: {
+                default: 'Settings',
+              },
+              parameter_refs: ['moduleName'],
             },
-            parameter_refs: [
-              'moduleName'
-            ],
-          }, {
-            id: 'lang',
-            label: {
-              default: 'Language'
+            {
+              id: 'lang',
+              label: {
+                default: 'Language',
+              },
+              type: 'actionPanel',
+              action_refs: ['language'],
             },
-            type: 'actionPanel',
-            action_refs: [
-              'language'
-            ],
-          }]
-        }
+          ],
+        },
       },
     };
   }
@@ -740,35 +753,48 @@ class VisualEditor extends React.Component {
           ref={(instance) => {
             this.CommonProperties = instance;
           }}
-          propertiesConfig={{containerType: "Custom", rightFlyout: true }}
+          propertiesConfig={{ containerType: 'Custom', rightFlyout: true }}
           propertiesInfo={this.getPropertiesInfo()} // required
           callbacks={{
-            applyPropertyChanges: (propertySet) => {
-              this.setState({
-                editorSettings: {
-                  moduleName: propertySet.moduleName
-                }
-              });
-              this.props.setModuleName( propertySet.moduleName);
-              localStorage.setItem('nlpEditorSettings', JSON.stringify({...this.state.editorSettings, ...propertySet}));
+            propertyListener: (data) => {
+              if (data.action === 'UPDATE_PROPERTY') {
+                const newEditorSettings = { ...this.state.editorSettings };
+                newEditorSettings[data.property?.name] = data.value;
+                this.setState({ editorSettings: newEditorSettings });
+              }
             },
-            closePropertiesDialog: () => {
+            closePropertiesDialog: (closeSource) => {
+              console.log(closeSource);
+              if (closeSource === 'apply') {
+                localStorage.setItem(
+                  'nlpEditorSettings',
+                  JSON.stringify(this.state.editorSettings),
+                );
+                this.setCurrentLanguage(this.state.editorSettings.language);
+              } else if (closeSource === 'cancel') {
+                this.setState({
+                  showSettings: false,
+                  editorSettings: localStorage.getItem('nlpEditorSettings')
+                    ? JSON.parse(localStorage.getItem('nlpEditorSettings'))
+                    : {
+                        moduleName: 'elyraNLPCanvas',
+                        language: 'en',
+                      },
+                });
+              }
               this.props.setShowRightPanel({ showPanel: false });
-              this.setState({
-                showSettings: false
-              });
             },
             actionHandler: (id, appData, data) => {
-              switch(id) {
+              switch (id) {
                 case 'language':
                   this.setState({ languageSelectModal: true });
                   break;
               }
-            }
+            },
           }} // required
           light // optional
         ></CommonProperties>
-      )
+      );
     }
     return (
       <Provider store={store}>
@@ -790,16 +816,23 @@ class VisualEditor extends React.Component {
           this.setCurrentLanguage(language);
           const editorSettings = {
             ...this.state.editorSettings,
-            ...{language: language}
+            language: language,
           };
-          this.setState({ languageSelectModal: false, editorSettings: editorSettings });
-          localStorage.setItem('nlpEditorSettings', JSON.stringify(editorSettings));
+          this.setState({
+            languageSelectModal: false,
+            editorSettings: editorSettings,
+          });
+          console.log(editorSettings);
+          localStorage.setItem(
+            'nlpEditorSettings',
+            JSON.stringify(editorSettings),
+          );
         }}
         onRequestClose={() => {
           this.setState({ languageSelectModal: false });
         }}
         languages={languages}
-        currentLanguage={this.getCurrentLanguage()}
+        currentLanguage={this.getCurrentLanguage() ?? 'en'}
       />
     );
   };
@@ -897,7 +930,7 @@ const mapDispatchToProps = (dispatch) => ({
   setShowRightPanel: (doShow) => dispatch(setShowRightPanel(doShow)),
   setShowDocumentViewer: (doShow) => dispatch(setShowDocumentViewer(doShow)),
   setDirty: (dirty) => dispatch(setDirty(dirty)),
-  setModuleName: (name) => dispatch(setModuleName(name))
+  setModuleName: (name) => dispatch(setModuleName(name)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(VisualEditor);

--- a/src/nlp-visual-editor/nlp-visual-editor.jsx
+++ b/src/nlp-visual-editor/nlp-visual-editor.jsx
@@ -62,6 +62,8 @@ import {
 
 const TIMER_TICK = 250; // 1/4 second
 const TIMER_TRIES = 40; // 2 minutes
+const DEFAULT_LANGUAGE = 'en';
+const DEFAULT_MODULE_NAME = 'elyraNLPCanvas';
 
 const languages = {
   ar: 'Arabic',
@@ -107,8 +109,8 @@ class VisualEditor extends React.Component {
       editorSettings: localStorage.getItem('nlpEditorSettings')
         ? JSON.parse(localStorage.getItem('nlpEditorSettings'))
         : {
-            moduleName: 'elyraNLPCanvas',
-            language: 'en',
+            moduleName: DEFAULT_MODULE_NAME,
+            language: DEFAULT_LANGUAGE,
           },
     };
 
@@ -263,7 +265,7 @@ class VisualEditor extends React.Component {
       body: JSON.stringify({
         workingId,
         payload,
-        language: this.getCurrentLanguage() ?? 'en',
+        language: this.getCurrentLanguage() ?? DEFAULT_LANGUAGE,
       }),
     })
       .then((res) => res.json())
@@ -777,8 +779,8 @@ class VisualEditor extends React.Component {
                   editorSettings: localStorage.getItem('nlpEditorSettings')
                     ? JSON.parse(localStorage.getItem('nlpEditorSettings'))
                     : {
-                        moduleName: 'elyraNLPCanvas',
-                        language: 'en',
+                        moduleName: DEFAULT_MODULE_NAME,
+                        language: DEFAULT_LANGUAGE,
                       },
                 });
               }
@@ -832,7 +834,7 @@ class VisualEditor extends React.Component {
           this.setState({ languageSelectModal: false });
         }}
         languages={languages}
-        currentLanguage={this.getCurrentLanguage() ?? 'en'}
+        currentLanguage={this.getCurrentLanguage() ?? DEFAULT_LANGUAGE}
       />
     );
   };


### PR DESCRIPTION
Fixes #96. The settings for the module name are exclusively stored in the browser memory. The language is stored as follows:
* If opening a blank pipeline:
  * If there is a language stored in the browser memory, use that language
  * Else use English
* If opening an existing pipeline:
  * If there is a language specified in the pipeline, use that language
  * Else use rules from first bullet